### PR TITLE
Update the docs after Argo Workflows 3.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ pipelines.
 
 ![demo](https://user-images.githubusercontent.com/74944/147889011-6917d13d-dea2-47e5-96bf-5f0d83064816.gif)
 
-Hermes builds upon Argo's yet to be released support for [template executor
-plugins](https://github.com/argoproj/argo-workflows/pull/7256). Once you have
-installed Hermes in your cluster, Argo will automatically launch an instance of
-Hermes for every workflow run and you will be able to interact with it directly
-from your workflow.
-
 ## Features
 
 - **Easy to use** – Hermes is a [template executor

--- a/docs/content/compatibility.md
+++ b/docs/content/compatibility.md
@@ -1,4 +1,4 @@
 !!! warning "Compatibilty warning"
 
     Hermes requires Argo Workflows 3.3+ which comes with support for [template
-    executor plugins](https://github.com/argoproj/argo-workflows/pull/7256).
+    executor plugins](https://argoproj.github.io/argo-workflows/executor_plugins/).

--- a/docs/content/compatibility.md
+++ b/docs/content/compatibility.md
@@ -1,7 +1,4 @@
-!!! warning "Compatibilty disclaimer"
+!!! warning "Compatibilty warning"
 
-    Hermes builds upon Argo Workflow's yet to be released support for [template
-    executor plugins](https://github.com/argoproj/argo-workflows/pull/7256),
-    which means that you will most likely not be able to use it in your cluster
-    yet. If you still want to try Hermes out, you will have to build and
-    install Argo Workflow from the PR.
+    Hermes requires Argo Workflows 3.3+ which comes with support for [template
+    executor plugins](https://github.com/argoproj/argo-workflows/pull/7256).


### PR DESCRIPTION
To be merged and released once [v3.3](https://github.com/argoproj/argo-workflows/issues/7589) of Argo Workflows is released.

## TODO

- [x] Point the links mentioning template executor plugins to the official documentation